### PR TITLE
feat: add theme color change feature in settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,13 +46,15 @@ class MyApp extends StatelessWidget {
           title: 'Marchkov Helper',
           debugShowCheckedModeBanner: false, // 添加这一行
           theme: ThemeData(
-            primarySwatch: Colors.blue,
+            colorScheme: ColorScheme.fromSeed(seedColor: themeProvider.selectedColor, brightness: Brightness.light), 
             brightness: Brightness.light,
+            useMaterial3: true,
             // 添加更多的主题配置以适配夜间模式
           ),
           darkTheme: ThemeData(
-            primarySwatch: Colors.blue,
+            colorScheme: ColorScheme.fromSeed(seedColor: themeProvider.selectedColor, brightness: Brightness.dark), 
             brightness: Brightness.dark,
+            useMaterial3: true,
             // 添加更多的暗黑主题配置
           ),
           themeMode: themeProvider.themeMode,

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -3,21 +3,36 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class ThemeProvider with ChangeNotifier {
   ThemeMode _themeMode = ThemeMode.light; // 默认设置为浅色模式
+  Color _selectedColor = Colors.blue; // 默认颜色
 
   ThemeMode get themeMode => _themeMode;
+  Color get selectedColor => _selectedColor;
 
   ThemeProvider() {
     _loadThemeMode();
+    _loadSelectedColor();
   }
 
   void _loadThemeMode() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     String? themeModeString = prefs.getString('themeMode');
     if (themeModeString != null) {
-      _themeMode =
-          ThemeMode.values.firstWhere((e) => e.toString() == themeModeString);
+      _themeMode = ThemeMode.values.firstWhere((e) => e.toString() == themeModeString);
       notifyListeners();
     }
+  }
+
+  // load user theme color from storage
+  void _loadSelectedColor() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    int? colorValue = prefs.getInt('selectedColor');
+    if (colorValue != null) {
+      _selectedColor = Color(colorValue);
+    } else {
+      final pekingRed = Color.fromRGBO(140, 0, 0, 1.0); // default color
+      _selectedColor = pekingRed;
+    }
+    notifyListeners();
   }
 
   void setThemeMode(ThemeMode mode) async {
@@ -25,5 +40,13 @@ class ThemeProvider with ChangeNotifier {
     notifyListeners();
     SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setString('themeMode', mode.toString());
+  }
+
+  // save user theme color to storage
+  void setSelectedColor(Color color) async {
+    _selectedColor = color;
+    notifyListeners();
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('selectedColor', color.value);
   }
 }

--- a/lib/screens/settings/theme_settings_page.dart
+++ b/lib/screens/settings/theme_settings_page.dart
@@ -20,9 +20,19 @@ class ThemeSettingsPage extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
+                _buildColorOption(context, themeProvider),
+                SizedBox(height: 5), // Spacing after color selection
+                Text(
+                  '主题颜色选择',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                SizedBox(height: 6), // Increased spacing before theme options
                 _buildThemeOption(context, '浅色模式', 'assets/day_mode.svg',
                     ThemeMode.light, themeProvider),
-                SizedBox(height: 24),
+                SizedBox(height: 20),
                 _buildThemeOption(context, '深色模式', 'assets/night_mode.svg',
                     ThemeMode.dark, themeProvider),
                 SizedBox(height: 24),
@@ -33,6 +43,42 @@ class ThemeSettingsPage extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildColorOption(BuildContext context, ThemeProvider themeProvider) {
+    final pekingRed = Color.fromRGBO(140, 0, 0, 1.0);
+    final colors = [
+      pekingRed,
+      Colors.purple,
+      Colors.green,
+      Colors.teal,
+      Colors.blue,
+      Colors.cyan,
+      Colors.yellow,
+    ];
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: colors.map((color) {
+        return GestureDetector(
+          onTap: () {
+            themeProvider.setSelectedColor(color);
+          },
+          child: Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: themeProvider.selectedColor == color ? Colors.black : Colors.transparent,
+                width: 1.6,
+              ),
+            ),
+          ),
+        );
+      }).toList(),
     );
   }
 


### PR DESCRIPTION
the color selection will be stored and automatically loaded each time the app starts, behaves just like `themeMode`.

<img width="534" alt="Screenshot 2024-10-24 at 21 59 53" src="https://github.com/user-attachments/assets/e177d7b4-1978-455b-ba2c-63bf010322c4">

<img width="534" alt="Screenshot 2024-10-24 at 22 01 14" src="https://github.com/user-attachments/assets/aca802cf-bb5a-48cb-b462-189e0df6cdb1">
