### PR TITLE
fix: fixed bug when reopening theme setting, the selected color "✓"  is not shown on UI due to color comparion failure

### DIFF
--- a/lib/screens/settings/theme_settings_page.dart
+++ b/lib/screens/settings/theme_settings_page.dart
@@ -5,6 +5,15 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+bool isSameColor(Color selected, dynamic color) {
+  if (color is MaterialColor) {
+    return selected == color ||
+        selected == color.shade500 ||
+        selected == color.shade700;
+  }
+  return selected == color;
+}
+
 class ThemeSettingsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -89,7 +98,7 @@ class ThemeSettingsPage extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: colors.map((color) {
-            final isSelected = themeProvider.selectedColor == color;
+            final isSelected = isSameColor(themeProvider.selectedColor, color);
             return Stack(
               children: [
                 Material(


### PR DESCRIPTION
the `color` in `children: colors.map((color)` could return `MaterialColor` instead of `Color` so we need to add a custom comparison logic for that.